### PR TITLE
add preapproved burn address example

### DIFF
--- a/script/DeployAndRedeemTokens-CampaignOnReceiveToken.s.sol
+++ b/script/DeployAndRedeemTokens-CampaignOnReceiveToken.s.sol
@@ -67,7 +67,9 @@ contract DeployAndRedeemTokens_CampaignOnReceiveToken is Script, Test {
         uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = 1;
 
-        redeemToken.setApprovalForAll(address(receiveToken), true);
+        // Individual user approvals not needed when setting the burn address.
+        // redeemToken.setApprovalForAll(address(receiveToken), true);
+        redeemToken.setBurnAddress(address(receiveToken));
 
         receiveToken.redeem(tokenIds, msg.sender, data);
 

--- a/src/test/ERC721OwnerMintable.sol
+++ b/src/test/ERC721OwnerMintable.sol
@@ -5,12 +5,28 @@ import {ERC721ConduitPreapproved_Solady} from "shipyard-core/src/tokens/erc721/E
 import {Ownable} from "solady/src/auth/Ownable.sol";
 
 contract ERC721OwnerMintable is ERC721ConduitPreapproved_Solady, Ownable {
+    /// @dev The address that can burn tokens without needing approval.
+    address private _burnAddress;
+
     constructor() ERC721ConduitPreapproved_Solady() {
         _initializeOwner(msg.sender);
     }
 
     function mint(address to, uint256 tokenId) public onlyOwner {
         _mint(to, tokenId);
+    }
+
+    function setBurnAddress(address burnAddress) public onlyOwner {
+        _burnAddress = burnAddress;
+    }
+
+    function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
+        bool approved = super.isApprovedForAll(owner, operator);
+        return operator == _burnAddress ? !approved : approved;
+    }
+
+    function _by(address from) internal view override returns (address result) {
+        return msg.sender == _burnAddress ? address(0) : super._by(from);
     }
 
     function name() public pure override returns (string memory) {


### PR DESCRIPTION
To save user approvals, when the campaign is on the RECEIVE token, the REDEEM token can preapprove the burn address. 

This works because the ERC7498 implementation of the redeem() function checks the user's balance first before proceeding with the transfer.